### PR TITLE
don't follow symlinks when matching against rules

### DIFF
--- a/igittigitt/igittigitt.py
+++ b/igittigitt/igittigitt.py
@@ -250,7 +250,7 @@ class IgnoreParser(object):
         """
         # match}}}
 
-        path_file_object = pathlib.Path(file_path).resolve()
+        path_file_object = pathlib.Path(os.path.abspath(os.path.expanduser(file_path)))
         is_file = path_file_object.is_file()
         str_file_path = str(path_file_object)
 


### PR DESCRIPTION
* **Please check if the Pull Request fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this Pull Request introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

resolves #18

* **What is the new behavior (if this is a feature change)?**

the `file_path` passed to `.match()` no longer uses `pathlib.Path.resolve()` to get an absolute path as it follows symlinks. Instead, `os.path.expanduser` and `os.path.abspath` are used to achieve the desired result of making the path absolute but without following symlinks.

* **Does this Pull Request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

yes, for those that implemented a workaround for this bug.