### PR TITLE
revert `IgnoreParser._parse_rule_file` to `parse_rule_file` as documented

### DIFF
--- a/igittigitt/igittigitt.py
+++ b/igittigitt/igittigitt.py
@@ -175,11 +175,9 @@ class IgnoreParser(object):
 
         for rule_file in rule_files:
             if not self.match(rule_file):
-                self._parse_rule_file(rule_file)
+                self.parse_rule_file(rule_file)
 
-    def _parse_rule_file(
-        self, rule_file: PathLikeOrString, base_dir: Optional[PathLikeOrString] = None,
-    ) -> None:
+    def parse_rule_file(self, rule_file: PathLikeOrString) -> None:
         """
         parse a git ignore file, create rules from a gitignore file
 
@@ -187,11 +185,6 @@ class IgnoreParser(object):
         ---------
         full_path
             the full path to the ignore file
-        base_dir
-            optional base dir, for testing purposes only.
-            the base dir is the parent of the rule file,
-            because rules are relative to the directory
-            were the rule file resides
 
         """
         path_rule_file = pathlib.Path(rule_file).resolve()


### PR DESCRIPTION
* **Please check if the Pull Request fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this Pull Request introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

resolves #22

This is something that tripped me up when first using this library as the documented method does not exist. I would rather have the method changed back to a public method than updating the docs to remove the reference as being able to add a gitignore file that is known to exist is more efficient than having it recursively search directories to find it (again).

* **What is the new behavior (if this is a feature change)?**

A method with signature `IgnoreParser.parse_rule_file(self, rule_file: PathLikeOrString) -> None`. In addition to reverting the name change of the method, the `base_dir` was removed as it is not used by the method.

* **Does this Pull Request introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes but the breaking change is to a protected method so a major release should not be required. Users will just need to change the name of the method being called from `_parse_rule_file` to `parse_rule_file`.
